### PR TITLE
Adding functionality to view QueryMetrics

### DIFF
--- a/Doobry.Tests/packages.config
+++ b/Doobry.Tests/packages.config
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package fileId="AvalonEdit" version="5.0.3" targetFramework="net452" />
-  <package fileId="DynamicData" version="5.0.3.2070-beta" targetFramework="net452" />
-  <package fileId="Microsoft.Azure.DocumentDB" version="1.10.0" targetFramework="net452" />
-  <package fileId="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
-  <package fileId="Rx-Core" version="2.2.5" targetFramework="net452" />
-  <package fileId="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
-  <package fileId="Rx-Linq" version="2.2.5" targetFramework="net452" />
-  <package fileId="Shouldly" version="2.8.0" targetFramework="net452" />
-  <package fileId="System.Reactive" version="3.0.0" targetFramework="net452" />
-  <package fileId="System.Reactive.Core" version="3.0.0" targetFramework="net452" />
-  <package fileId="System.Reactive.Interfaces" version="3.0.0" targetFramework="net452" />
-  <package fileId="System.Reactive.Linq" version="3.0.0" targetFramework="net452" />
-  <package fileId="System.Reactive.PlatformServices" version="3.0.0" targetFramework="net452" />
-  <package fileId="System.Reactive.Windows.Threading" version="3.0.0" targetFramework="net452" />
-  <package fileId="xunit" version="2.1.0" targetFramework="net452" />
-  <package fileId="xunit.abstractions" version="2.0.0" targetFramework="net452" />
-  <package fileId="xunit.assert" version="2.1.0" targetFramework="net452" />
-  <package fileId="xunit.core" version="2.1.0" targetFramework="net452" />
-  <package fileId="xunit.extensibility.core" version="2.1.0" targetFramework="net452" />
-  <package fileId="xunit.extensibility.execution" version="2.1.0" targetFramework="net452" />
+  <package id="AvalonEdit" version="5.0.3" targetFramework="net452" />
+  <package id="DynamicData" version="5.0.3.2070-beta" targetFramework="net452" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.10.0" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net452" />
+  <package id="Shouldly" version="2.8.0" targetFramework="net452" />
+  <package id="System.Reactive" version="3.0.0" targetFramework="net452" />
+  <package id="System.Reactive.Core" version="3.0.0" targetFramework="net452" />
+  <package id="System.Reactive.Interfaces" version="3.0.0" targetFramework="net452" />
+  <package id="System.Reactive.Linq" version="3.0.0" targetFramework="net452" />
+  <package id="System.Reactive.PlatformServices" version="3.0.0" targetFramework="net452" />
+  <package id="System.Reactive.Windows.Threading" version="3.0.0" targetFramework="net452" />
+  <package id="xunit" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
+  <package id="xunit.assert" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.core" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net452" />
+  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net452" />
 </packages>

--- a/Doobry/Doobry.csproj
+++ b/Doobry/Doobry.csproj
@@ -80,9 +80,8 @@
       <HintPath>..\packages\MaterialDesignThemes.2.2.1-ci761\lib\net45\MaterialDesignThemes.Wpf.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.10.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Azure.DocumentDB.1.10.0\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Azure.Documents.Client, Version=1.22.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Azure.DocumentDB.1.22.0\lib\net45\Microsoft.Azure.Documents.Client.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
@@ -196,6 +195,7 @@
     <Compile Include="Features\QueryDeveloper\DocumentId.cs" />
     <Compile Include="DoobryRegistry.cs" />
     <Compile Include="Features\QueryDeveloper\QueryDeveloperFeatureFactory.cs" />
+    <Compile Include="Features\QueryDeveloper\ResultMetadata.cs" />
     <Compile Include="Features\TabCloseReason.cs" />
     <Compile Include="Features\TabContentLifetimeHost.cs" />
     <Compile Include="Infrastructure\Command.cs" />
@@ -317,7 +317,9 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -445,9 +447,9 @@ foreach (var item in filesToCleanup)
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.4\build\dotnet\Fody.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Azure.DocumentDB.1.10.0\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Azure.DocumentDB.1.10.0\build\Microsoft.Azure.DocumentDB.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Azure.DocumentDB.1.22.0\build\Microsoft.Azure.DocumentDB.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Azure.DocumentDB.1.22.0\build\Microsoft.Azure.DocumentDB.targets'))" />
   </Target>
-  <Import Project="..\packages\Microsoft.Azure.DocumentDB.1.10.0\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\packages\Microsoft.Azure.DocumentDB.1.10.0\build\Microsoft.Azure.DocumentDB.targets')" />
+  <Import Project="..\packages\Microsoft.Azure.DocumentDB.1.22.0\build\Microsoft.Azure.DocumentDB.targets" Condition="Exists('..\packages\Microsoft.Azure.DocumentDB.1.22.0\build\Microsoft.Azure.DocumentDB.targets')" />
   <!--
   <Target Name="CleanReferenceCopyLocalPaths" AfterTargets="AfterBuild;NonWinFodyTarget" Condition="'$(Configuration)' == 'Release' ">
     <CosturaCleanup Config="FodyWeavers.xml" Files="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename)%(Extension)')" />

--- a/Doobry/Features/QueryDeveloper/Result.cs
+++ b/Doobry/Features/QueryDeveloper/Result.cs
@@ -1,3 +1,6 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
 namespace Doobry.Features.QueryDeveloper
 {
     public class Result
@@ -9,7 +12,7 @@ namespace Doobry.Features.QueryDeveloper
             Id = id;
 
             Row = row;
-            Data = data;
+            Data = JValue.Parse(data).ToString(Formatting.Indented);
         }
 
         public DocumentId Id { get; }

--- a/Doobry/Features/QueryDeveloper/ResultMetadata.cs
+++ b/Doobry/Features/QueryDeveloper/ResultMetadata.cs
@@ -1,0 +1,169 @@
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+
+namespace Doobry.Features.QueryDeveloper
+{
+    public class ResultMetrics
+    {
+        public ResultMetrics(FeedResponse<dynamic> result)
+        {
+            this.id = "Query Metrics";
+            this._self = "Query Metrics";
+            this.SessionToken = result.SessionToken;
+            this.RequestCharge = result.RequestCharge;
+            this.Count = result.Count;
+            this.CollectionQuota = result.CollectionQuota;
+            this.CollectionSizeQuota = result.CollectionSizeQuota;
+            this.CollectionSizeUsage = result.CollectionSizeUsage;
+            this.CollectionUsage = result.CollectionUsage;
+            this.DatabaseQuota = result.DatabaseQuota;
+            this.DatabaseUsage = result.DatabaseUsage;
+            this.PermissionQuota = result.PermissionQuota;
+            this.PermissionUsage = result.PermissionUsage;
+            this.StoredProceduresQuota = result.StoredProceduresQuota;
+            this.StoredProceduresUsage = result.StoredProceduresUsage;
+            this.TriggersQuota = result.TriggersQuota;
+            this.TriggersUsage = result.TriggersUsage;
+            this.UserDefinedFunctionsQuota = result.UserDefinedFunctionsQuota;
+            this.UserDefinedFunctionsUsage = result.UserDefinedFunctionsUsage;
+            this.UserQuota = result.UserQuota;
+            this.UserUsage = result.UserUsage;
+            this.ResponseHeaders = result.ResponseHeaders;
+            this.ActivityId = result.ActivityId;
+            this.ContentLocation = result.ContentLocation;
+            this.CurrentResourceQuotaUsage = result.CurrentResourceQuotaUsage;
+            this.MaxResourceQuota = result.MaxResourceQuota;
+            this.ResponseContinuation = result.ResponseContinuation;
+            this.QueryMetrics = result.QueryMetrics;
+        }
+
+        public string id { get; }
+        public string _self { get; }
+        //
+        // Summary:
+        //     Gets the session token for use in sesssion consistency reads from the Azure DocumentDB
+        //     database service.
+        public string SessionToken { get; }
+        //
+        // Summary:
+        //     Gets the continuation token to be used for continuing enumeration of the Azure
+        //     DocumentDB database service.
+        public string ResponseContinuation { get; }
+        //
+        // Summary:
+        //     Gets the activity ID for the request from the Azure DocumentDB database service.
+        public string ActivityId { get; }
+        //
+        // Summary:
+        //     Gets the request charge for this request from the Azure DocumentDB database service.
+        public double RequestCharge { get; }
+        //
+        // Summary:
+        //     Gets the current size of this entity from the Azure DocumentDB database service.
+        public string CurrentResourceQuotaUsage { get; }
+        //
+        // Summary:
+        //     Gets the maximum size limit for this entity from the Azure DocumentDB database
+        //     service.
+        public string MaxResourceQuota { get; }
+        //
+        // Summary:
+        //     Gets the number of items returned in the response from the Azure DocumentDB database
+        //     service.
+        public int Count { get; }
+        //
+        // Summary:
+        //     Gets the current number of user defined functions for a collection from the Azure
+        //     DocumentDB database service.
+        public long UserDefinedFunctionsUsage { get; }
+        //
+        // Summary:
+        //     Gets the maximum quota of user defined functions for a collection from the Azure
+        //     DocumentDB database service.
+        public long UserDefinedFunctionsQuota { get; }
+        //
+        // Summary:
+        //     Get the current number of triggers for a collection from the Azure DocumentDB
+        //     database service.
+        public long TriggersUsage { get; }
+        //
+        // Summary:
+        //     Gets the maximum quota of triggers for a collection from the Azure DocumentDB
+        //     database service.
+        public long TriggersQuota { get; }
+        //
+        // Summary:
+        //     Gets the current number of stored procedures for a collection from the Azure
+        //     DocumentDB database service.
+        public long StoredProceduresUsage { get; }
+        //
+        // Summary:
+        //     Gets the maximum quota of stored procedures for a collection from the Azure DocumentDB
+        //     database service.
+        public long StoredProceduresQuota { get; }
+        //
+        // Summary:
+        //     Gets the current size of a collection in kilobytes from the Azure DocumentDB
+        //     database service.
+        public long CollectionSizeUsage { get; }
+        //
+        // Summary:
+        //     Gets the maximum size of a collection in kilobytes from the Azure DocumentDB
+        //     database service.
+        public long CollectionSizeQuota { get; }
+        //
+        // Summary:
+        //     Gets the current number of permission resources within the account from the Azure
+        //     DocumentDB database service.
+        public long PermissionUsage { get; }
+        //
+        // Summary:
+        //     Gets the maximum quota for permission resources within an account from the Azure
+        //     DocumentDB database service.
+        public long PermissionQuota { get; }
+        //
+        // Summary:
+        //     Gets the current number of user resources within the account from the Azure DocumentDB
+        //     database service.
+        public long UserUsage { get; }
+        //
+        // Summary:
+        //     Gets the maximum quota for user resources within an account from the Azure DocumentDB
+        //     database service.
+        public long UserQuota { get; }
+        //
+        // Summary:
+        //     Gets the current number of collection resources within the account from the Azure
+        //     DocumentDB database service.
+        public long CollectionUsage { get; }
+        //
+        // Summary:
+        //     Gets the maximum quota for collection resources within an account from the Azure
+        //     DocumentDB database service.
+        public long CollectionQuota { get; }
+        //
+        // Summary:
+        //     Gets the current number of database resources within the account from the Azure
+        //     DocumentDB database service.
+        public long DatabaseUsage { get; }
+        //
+        // Summary:
+        //     Gets the maximum quota for database resources within the account from the Azure
+        //     DocumentDB database service.
+        public long DatabaseQuota { get; }
+        //
+        // Summary:
+        //     Gets the content parent location, for example, dbs/foo/colls/bar, from the Azure
+        //     DocumentDB database service.
+        public string ContentLocation { get; }
+        //
+        // Summary:
+        //     Gets the response headers from the Azure DocumentDB database service.
+        public NameValueCollection ResponseHeaders { get; }
+
+        public IReadOnlyDictionary<string, QueryMetrics> QueryMetrics { get; }
+
+    }
+}

--- a/Doobry/Features/QueryDeveloper/ResultSet.cs
+++ b/Doobry/Features/QueryDeveloper/ResultSet.cs
@@ -9,12 +9,15 @@ using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Azure.Documents.Client;
+using Newtonsoft.Json.Linq;
 
 namespace Doobry.Features.QueryDeveloper
 {
     public class ResultSet
     {        
         private readonly ObservableCollection<Result> _results;
+        private readonly ObservableCollection<FeedResponse<dynamic>> _resultMetadatas;
 
         public ResultSet(IEnumerable<Result> results)
         {            
@@ -22,6 +25,19 @@ namespace Doobry.Features.QueryDeveloper
 
             _results = new ObservableCollection<Result>(results);
             Results = new ReadOnlyObservableCollection<Result>(_results);            
+        }
+
+        public ResultSet(IEnumerable<Result> results, FeedResponse<dynamic> resultMetadatas)
+        {
+            if (results == null) throw new ArgumentNullException(nameof(results));
+
+            _results = new ObservableCollection<Result>(results);
+            Results = new ReadOnlyObservableCollection<Result>(_results);
+
+            if (resultMetadatas == null) throw new ArgumentNullException(nameof(resultMetadatas));
+
+            _resultMetadatas = new ObservableCollection<FeedResponse<dynamic>>(new List<FeedResponse<dynamic>> { resultMetadatas });
+            ResultMetadata = new ResultMetrics(resultMetadatas);
         }
 
         public ResultSet(string error)
@@ -40,6 +56,20 @@ namespace Doobry.Features.QueryDeveloper
         public string Error { get; }
 
         public ReadOnlyObservableCollection<Result> Results { get; }
+        public ResultMetrics ResultMetadata { get; }
+        public string ResultMetadataText {  get
+            {
+                if (_resultMetadatas != null && _resultMetadatas.Count() > 0)
+                {
+                    FeedResponse<dynamic> metadata = _resultMetadatas[0];
+                    ResultMetrics details = new ResultMetrics(metadata);
+                    string resultMetadataText = JsonConvert.SerializeObject(details, Formatting.Indented);
+                    return resultMetadataText;
+                }
+                return "";
+            }
+        }
+
 
         public void Append(IEnumerable<string> results)
         {            

--- a/Doobry/Features/QueryDeveloper/ResultSetExplorer.xaml
+++ b/Doobry/Features/QueryDeveloper/ResultSetExplorer.xaml
@@ -24,25 +24,6 @@
                     <Run FontSize="10" Text="{Binding Id, Mode=OneWay}" FontStyle="Italic"  />
             </TextBlock>
         </DataTemplate>
-        <!--
-        <DataTemplate x:Key="ResultDataTenplate" DataType="local:Result">
-            <materialDesign:TransitioningContent OpeningEffectsOffset="{materialDesign:IndexedItemOffsetMultiplier 0:0:0.05}">
-                <materialDesign:TransitioningContent.OpeningEffects>
-                    <materialDesign:TransitionEffect Kind="SlideInFromRight" />
-                </materialDesign:TransitioningContent.OpeningEffects>
-                <TextBlock>
-                    <TextBlock.InputBindings>
-                        <MouseBinding MouseAction="LeftDoubleClick" 
-                                  Command="{Binding ElementName=ResultsItems, Path=DataContext.EditDocumentCommand}"
-                                  CommandParameter="{Binding }"/>
-                    </TextBlock.InputBindings>
-                <Run Text="{Binding Row, Mode=OneWay}" />                
-                <Run Text=" " />
-                <Run FontSize="10" Text="{Binding Id, Mode=OneWay}" FontStyle="Italic"  />
-                </TextBlock>
-            </materialDesign:TransitioningContent>            
-        </DataTemplate>
-        -->
     </UserControl.Resources>
     <Grid>
         <Grid Visibility="{Binding IsError, Converter={StaticResource InvertedBooleanToVisibilityConverter}}">

--- a/Doobry/Features/QueryDeveloper/ResultSetExplorerViewModel.cs
+++ b/Doobry/Features/QueryDeveloper/ResultSetExplorerViewModel.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Windows.Input;
 using Doobry.Infrastructure;
 
+
 namespace Doobry.Features.QueryDeveloper
 {
     public class ResultSetExplorerViewModel : INotifyPropertyChanged
@@ -15,6 +16,7 @@ namespace Doobry.Features.QueryDeveloper
         private int _selectedRow = -1;
         private ResultSet _resultSet;
         private bool _isError;
+        private bool _isQueryDetails;
         private string _error;
 
         public ResultSetExplorerViewModel(ICommand fetchMoreCommand, ICommand editDocumentCommand,
@@ -40,21 +42,26 @@ namespace Doobry.Features.QueryDeveloper
                     if (!string.IsNullOrEmpty(_resultSet.Error))
                     {
                         IsError = true;
+                        IsQueryDetails = false;
                         Error = _resultSet.Error;
                         SelectedRow = -1;
                     }
                     else
                     {
                         IsError = false;
+                        IsQueryDetails = true;
                         Error = null;
                         if (_resultSet.Results.Count > 0)
                             SelectedRow = 0;
                         else
                             SelectedRow = -1;
+
+                        
                     }
                 }
                 else
                     SelectedRow = -1;
+
             }
         }
 
@@ -65,6 +72,12 @@ namespace Doobry.Features.QueryDeveloper
         public ICommand EditDocumentCommand { get; }
 
         public ICommand SaveDocumentCommand { get; }
+
+        public bool IsQueryDetails
+        {
+            get { return _isQueryDetails; }
+            private set { this.MutateVerbose(ref _isQueryDetails, value, RaisePropertyChanged()); }
+        }
 
         public bool IsError
         {

--- a/Doobry/Settings/ConnectionsManager.xaml
+++ b/Doobry/Settings/ConnectionsManager.xaml
@@ -58,6 +58,13 @@
                                         CommandParameter="{Binding }">
                                     <materialDesign:PackIcon Kind="Pencil" />
                                 </Button>
+                                <Button Style="{DynamicResource MaterialDesignFlatButton}"
+                                    Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}"
+                                    CommandParameter="{Binding }"
+                                    Margin="0 4 0 0" Width="80"
+                                    DockPanel.Dock="Left">
+                                    DETAILS
+                                </Button>
                                 <!--
                                 <Button Style="{DynamicResource MaterialDesignFlatButton}"
                                         Margin="2 0 0 0">

--- a/Doobry/packages.config
+++ b/Doobry/packages.config
@@ -1,26 +1,26 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package fileId="AvalonEdit" version="5.0.3" targetFramework="net452" />
-  <package fileId="Costura.Fody" version="1.3.3.0" targetFramework="net452" developmentDependency="true" />
-  <package fileId="DeltaCompressionDotNet" version="1.0.0" targetFramework="net452" />
-  <package fileId="Dragablz" version="0.0.3.182" targetFramework="net452" />
-  <package fileId="DynamicData" version="5.0.3.2070-beta" targetFramework="net452" />
-  <package fileId="Fody" version="1.29.4" targetFramework="net452" developmentDependency="true" />
-  <package fileId="MaterialDesignColors" version="1.1.3" targetFramework="net452" />
-  <package fileId="MaterialDesignThemes" version="2.2.1-ci761" targetFramework="net452" />
-  <package fileId="Microsoft.Azure.DocumentDB" version="1.10.0" targetFramework="net452" />
-  <package fileId="Mono.Cecil" version="0.9.6.1" targetFramework="net452" />
-  <package fileId="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package fileId="Rx-Core" version="2.2.5" targetFramework="net452" />
-  <package fileId="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
-  <package fileId="Rx-Linq" version="2.2.5" targetFramework="net452" />
-  <package fileId="Splat" version="1.6.2" targetFramework="net452" />
-  <package fileId="squirrel.windows" version="1.4.4" targetFramework="net452" />
-  <package fileId="StructureMap" version="4.4.2" targetFramework="net452" />
-  <package fileId="System.Reactive" version="3.0.0" targetFramework="net452" />
-  <package fileId="System.Reactive.Core" version="3.0.0" targetFramework="net452" />
-  <package fileId="System.Reactive.Interfaces" version="3.0.0" targetFramework="net452" />
-  <package fileId="System.Reactive.Linq" version="3.0.0" targetFramework="net452" />
-  <package fileId="System.Reactive.PlatformServices" version="3.0.0" targetFramework="net452" />
-  <package fileId="System.Reactive.Windows.Threading" version="3.0.0" targetFramework="net452" />
+  <package id="AvalonEdit" version="5.0.3" targetFramework="net452" />
+  <package id="Costura.Fody" version="1.3.3.0" targetFramework="net452" developmentDependency="true" />
+  <package id="DeltaCompressionDotNet" version="1.0.0" targetFramework="net452" />
+  <package id="Dragablz" version="0.0.3.182" targetFramework="net452" />
+  <package id="DynamicData" version="5.0.3.2070-beta" targetFramework="net452" />
+  <package id="Fody" version="1.29.4" targetFramework="net452" developmentDependency="true" />
+  <package id="MaterialDesignColors" version="1.1.3" targetFramework="net452" />
+  <package id="MaterialDesignThemes" version="2.2.1-ci761" targetFramework="net452" />
+  <package id="Microsoft.Azure.DocumentDB" version="1.22.0" targetFramework="net452" />
+  <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="net452" />
+  <package id="Splat" version="1.6.2" targetFramework="net452" />
+  <package id="squirrel.windows" version="1.4.4" targetFramework="net452" />
+  <package id="StructureMap" version="4.4.2" targetFramework="net452" />
+  <package id="System.Reactive" version="3.0.0" targetFramework="net452" />
+  <package id="System.Reactive.Core" version="3.0.0" targetFramework="net452" />
+  <package id="System.Reactive.Interfaces" version="3.0.0" targetFramework="net452" />
+  <package id="System.Reactive.Linq" version="3.0.0" targetFramework="net452" />
+  <package id="System.Reactive.PlatformServices" version="3.0.0" targetFramework="net452" />
+  <package id="System.Reactive.Windows.Threading" version="3.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
I was writing a WPF based app to view Cosmos Queries when I came across Doobry and it was almost exactly what I was looking for. The only thing missing was the ability to view Query Metrics as I needed to be able to identify why indexes weren't getting applied. This pull request adds the ability to view query metrics as an additional line in the list of documents.